### PR TITLE
add timeout to all container list

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,10 @@ func main() {
 		os.Exit(0)
 	}
 
+	if os.Getenv("CATTLE_DEBUG") != "" {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
 	logrus.Info("Launching agent")
 
 	url := os.Getenv("CATTLE_URL")


### PR DESCRIPTION
@sangeethah still found that agent falls in reconnecting state when lots of containers bubble up. The problem may exist in doInspect cause each `do_instance_inspect` will call `containerList` when the number of containers grows it will be a pain for docker daemon. So add timeout for all `containeList` and reduce the times of calling `containerlist` to see if we can solve that problem. @ibuildthecloud 
