### PR TITLE
Disable cgo on build

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -6,4 +6,4 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-go build -ldflags "-X main.VERSION=$VERSION -linkmode external -extldflags -static -s" -o bin/agent
+CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION -linkmode external -extldflags -static -s" -o bin/agent


### PR DESCRIPTION
Partially adddresses https://github.com/rancher/rancher/issues/6111

I think we just need to add GCO_ENABLED=false to our builds

With this test code:
```
package main

import (
	"net"
	"fmt"
)

func main() {
	_, err := net.ResolveIPAddr("ip", "test.local") 
	fmt.Printf("%v", err)
}
```
if compiled like we currently do on ubuntu:
```
go build -ldflags "-linkmode external -extldflags -static -s"
```
and then ran on centos, you get a panic.

But if you compile it with CGO_ENABLED=0 like:
```
CGO_ENABLED=0 go build -ldflags "-linkmode external -extldflags -static -s"
```
it works properly on centos
