### PR TITLE
fix for externalID and ip label

### DIFF
--- a/core/compute/compute.go
+++ b/core/compute/compute.go
@@ -104,6 +104,9 @@ func DoInstanceActivate(instance model.Instance, host model.Host, progress *prog
 	containerID := container.ID
 	created := false
 	if containerID == "" {
+		if instance.ExternalID != "" {
+			return errors.New(constants.DoInstanceActivateError + "ExternalID is present in instance but can't be found on the host")
+		}
 		newID, err := createContainer(dockerClient, &config, &hostConfig, &networkConfig, imageTag, instance, name, progress)
 		if err != nil {
 			return errors.Wrap(err, constants.DoInstanceActivateError+"failed to create container")

--- a/core/compute/compute_unix.go
+++ b/core/compute/compute_unix.go
@@ -161,8 +161,10 @@ func setupMacAndIP(instance model.Instance, config *container.Config, setMac boo
 		ipAddress := ""
 		for _, ip := range nic.IPAddresses {
 			if ip.Role == "primary" {
-				ipAddress = fmt.Sprintf("%s/%s", ip.Address, strconv.Itoa(ip.Subnet.CidrSize))
-				break
+				if ip.Address != "" && ip.Subnet.CidrSize != 0 {
+					ipAddress = fmt.Sprintf("%s/%s", ip.Address, strconv.Itoa(ip.Subnet.CidrSize))
+					break
+				}
 			}
 		}
 		if ipAddress != "" {

--- a/handlers/compute_unix_test.go
+++ b/handlers/compute_unix_test.go
@@ -246,3 +246,41 @@ func (s *ComputeTestSuite) TestInstanceActivateAgent(c *check.C) {
 	c.Assert(ok2, check.Equals, true)
 	c.Assert(ok3, check.Equals, true)
 }
+
+func (s *ComputeTestSuite) TestExternalIDInstanceActivate(c *check.C) {
+	deleteContainer("/c861f990-4472-4fa1-960f-65171b544c28")
+
+	rawEvent := loadEvent("./test_events/instance_activate_basic", c)
+	event, instance, _ := unmarshalEventAndInstanceFields(rawEvent, c)
+
+	instance["externalId"] = "123456"
+	rawEvent = marshalEvent(event, c)
+	reply := testEvent(rawEvent, c)
+	_, ok := utils.GetFieldsIfExist(reply.Data, "instanceHostMap", "instance", "+data", "dockerContainer")
+	if ok {
+		c.Fatal("Should error out. ExternalID is present but container is not on the host")
+	}
+
+	//launch a container. Stop it and then start it again with external ID, should succeed.
+	rawEvent = loadEvent("./test_events/instance_activate_basic", c)
+	reply = testEvent(rawEvent, c)
+	container, ok := utils.GetFieldsIfExist(reply.Data, "instanceHostMap", "instance", "+data", "dockerContainer")
+	if !ok {
+		c.Fatal("No id found")
+	}
+	dockerClient := docker.GetClient(docker.DefaultVersion)
+	t := time.Duration(0)
+	err := dockerClient.ContainerStop(context.Background(), container.(types.Container).ID, &t)
+	if err != nil {
+		c.Fatal(err)
+	}
+	rawEvent = loadEvent("./test_events/instance_activate_basic", c)
+	event, instance, _ = unmarshalEventAndInstanceFields(rawEvent, c)
+	instance["externalId"] = container.(types.Container).ID
+	rawEvent = marshalEvent(event, c)
+	reply = testEvent(rawEvent, c)
+	_, ok = utils.GetFieldsIfExist(reply.Data, "instanceHostMap", "instance", "+data", "dockerContainer")
+	if !ok {
+		c.Fatal("No id found")
+	}
+}


### PR DESCRIPTION
Fix two bad scenarios which happens in agent now:
1. If instance.activate receive an instance with an externalID and if we can't find the externalID(which is the containerID), we should error out. The reason why we do that: the instance with an external ID is usually back-populated and have more context than the original one. We don't want the instance to be created if we can't find the externalID on the host because it have more context than it usually has and might break things. So instead it should error out and cattle will create a new entry in database for the new instance.
2. Don't set ip label if CIdr size is not set. This prevents agent setting IP label from back-populated containers. 