### PR TITLE
Make compute lock be more fine grained for start

### DIFF
--- a/core/compute/compute.go
+++ b/core/compute/compute.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/agent/core/storage"
 	"github.com/rancher/agent/model"
 	"github.com/rancher/agent/utilities/constants"
+	dutils "github.com/rancher/agent/utilities/docker"
 	"github.com/rancher/agent/utilities/utils"
 	"golang.org/x/net/context"
 )
@@ -115,7 +116,10 @@ func DoInstanceActivate(instance model.Instance, host model.Host, progress *prog
 		created = true
 	}
 
-	if startErr := dockerClient.ContainerStart(context.Background(), containerID, types.ContainerStartOptions{}); startErr != nil {
+	startErr := dutils.Serialize(func() error {
+		return dockerClient.ContainerStart(context.Background(), containerID, types.ContainerStartOptions{})
+	})
+	if startErr != nil {
 		if created {
 			if err := utils.RemoveContainer(dockerClient, containerID); err != nil {
 				return errors.Wrap(err, constants.DoInstanceActivateError+"failed to remove container")

--- a/utilities/docker/compute_lock.go
+++ b/utilities/docker/compute_lock.go
@@ -1,0 +1,37 @@
+package docker
+
+import (
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	revents "github.com/rancher/event-subscriber/events"
+	"github.com/rancher/go-rancher/v2"
+)
+
+var (
+	SerializeCompute = false
+	computeLock      = sync.Mutex{}
+)
+
+func SerializeHandler(f revents.EventHandler) revents.EventHandler {
+	return func(event *revents.Event, cli *client.RancherClient) error {
+		return Serialize(func() error {
+			return f(event, cli)
+		})
+	}
+}
+
+func Serialize(f func() error) error {
+	if !SerializeCompute {
+		return f()
+	}
+
+	computeLock.Lock()
+	logrus.Info("Compute lock")
+	defer func() {
+		logrus.Info("Compute unlock")
+		computeLock.Unlock()
+	}()
+
+	return f()
+}


### PR DESCRIPTION
On container activate we may need to pull an image or wait for container
IP to be assigned.  During this time we do not want to block other
container operations.