### PR TITLE
remove 1.11 from the matrix

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,6 @@
 matrix:
   DOCKER_VERSION:
   - 1.10.3
-  - 1.11.2
   - 1.12.1
   - 1.13.1
 pipeline:


### PR DESCRIPTION
since we no longer support docker 1.11.x, there is no need to add it to build matrix.