### PR TITLE
WIP: add a constant label to identify ec2 instances

### DIFF
--- a/cloudprovider/aws/aws_provider.go
+++ b/cloudprovider/aws/aws_provider.go
@@ -18,6 +18,7 @@ const (
 	availabilityZoneLabel = "ec2.availability_zone"
 	infoFile              = "info.json"
 	tempFile              = "temp.json"
+	ec2_key               = "ec2_instance"
 )
 
 type Provider struct {
@@ -79,6 +80,7 @@ func (p Provider) GetCloudProviderInfo() bool {
 		i.Labels = map[string]string{}
 		i.Labels[regionLabel] = document.Region
 		i.Labels[availabilityZoneLabel] = document.AvailabilityZone
+		i.Labels[ec2_key] = "true"
 		bytes, err := json.Marshal(i)
 		if err != nil {
 			logrus.Error(err)


### PR DESCRIPTION
Add a label `ec2_instance=true` to identify ec2 instance. This label can be used to apply host-affinity rule to onlu schedule rancher-ebs driver to only ec2 hosts.