### PR TITLE
Rollback external ID check

### DIFF
--- a/core/compute/compute.go
+++ b/core/compute/compute.go
@@ -105,9 +105,6 @@ func DoInstanceActivate(instance model.Instance, host model.Host, progress *prog
 	containerID := container.ID
 	created := false
 	if containerID == "" {
-		if instance.ExternalID != "" {
-			return errors.New(constants.DoInstanceActivateError + "ExternalID is present in instance but can't be found on the host")
-		}
 		newID, err := createContainer(dockerClient, &config, &hostConfig, &networkConfig, imageTag, instance, name, progress)
 		if err != nil {
 			return errors.Wrap(err, constants.DoInstanceActivateError+"failed to create container")


### PR DESCRIPTION
This error is not handle properly in service.reconcile.
A partial rollback of https://github.com/rancher/agent/pull/149. That PR had another change to fix the symptom of the bug that that PR was addressing, so removing this additional fix is ok.