### PR TITLE
Fix label logic

### DIFF
--- a/core/compute/compute.go
+++ b/core/compute/compute.go
@@ -52,6 +52,8 @@ func DoInstanceActivate(instance model.Instance, host model.Host, progress *prog
 
 	initializeMaps(&config, &hostConfig)
 
+	setupLabels(instance.Data.Fields.Labels, &config)
+
 	utils.AddLabel(&config, constants.UUIDLabel, instance.UUID)
 
 	if len(instanceName) > 0 {
@@ -93,8 +95,6 @@ func DoInstanceActivate(instance model.Instance, host model.Host, progress *prog
 	setupComputeResourceFields(&hostConfig, instance)
 
 	setupHeathConfig(instance.Data.Fields, &config)
-
-	setupLabels(instance.Data.Fields.Labels, &config)
 
 	container, err := utils.GetContainer(dockerClient, instance, false)
 	if err != nil {

--- a/core/compute/compute_common.go
+++ b/core/compute/compute_common.go
@@ -357,10 +357,6 @@ func setupFieldsConfig(fields model.InstanceFields, config *container.Config) {
 
 	config.Domainname = fields.DomainName
 
-	for k, v := range fields.Labels {
-		config.Labels[k] = v
-	}
-
 	config.StopSignal = fields.StopSignal
 
 	config.User = fields.User


### PR DESCRIPTION
Set user labels before setting rancher labels so that the rancher
labels will override any user labels. Remove redundant setting of
labels.