### PR TITLE
add interval for container stats

### DIFF
--- a/service/hostapi/stats/container_stats.go
+++ b/service/hostapi/stats/container_stats.go
@@ -126,6 +126,7 @@ func (s *ContainerStatsHandler) Handle(key string, initialMessage string, incomi
 			if err != nil {
 				return
 			}
+			time.Sleep(time.Second * 1)
 		}
 	} else {
 		contList, err := dclient.ContainerList(context.Background(), types.ContainerListOptions{})
@@ -167,6 +168,7 @@ func (s *ContainerStatsHandler) Handle(key string, initialMessage string, incomi
 			if err != nil {
 				return
 			}
+			time.Sleep(time.Second * 1)
 		}
 	}
 }


### PR DESCRIPTION
By default stats from docker API is returned with 1 second interval. Thus we don't set time interval for container stats.
However, this might raise an issue where the agent is overloaded and aggresively write data to a websocket connection in a for loop