### PR TITLE
exit for loop when nothing to write for 1.6

### DIFF
--- a/service/hostapi/stats/container_stats.go
+++ b/service/hostapi/stats/container_stats.go
@@ -155,6 +155,9 @@ func (s *ContainerStatsHandler) Handle(key string, initialMessage string, incomi
 		}
 		for {
 			infos := []containerInfo{}
+			if len(readerMap) == 0 {
+				return
+			}
 			for id, r := range readerMap {
 				cInfo, err := getContainerStats(r, id, pidMap[id])
 				if err != nil {


### PR DESCRIPTION
fixed an issue when the readerMap is empty, we don't write any data but keep the for loop running. These will keep agent in a high cpu usage and will never recover.
So exit the loop if we don't have anything to write.