### PR TITLE
Trim key and value for user entered labels

### DIFF
--- a/utilities/config/config.go
+++ b/utilities/config/config.go
@@ -206,7 +206,7 @@ func Labels() map[string]string {
 			logrus.Error(err)
 		}
 		for k, v := range m {
-			ret[k] = v[0]
+			ret[strings.TrimSpace(k)] = strings.TrimSpace(v[0])
 		}
 	}
 	return ret


### PR DESCRIPTION
Get rid of trailing and leading whitespace in user provided labels.
This is the best way to ensure that the label keys and values have
consistent values throughout Rancher.