### PR TITLE
Broaden error string search

### DIFF
--- a/service/hostapi/logs/logs.go
+++ b/service/hostapi/logs/logs.go
@@ -116,7 +116,7 @@ func (l *Handler) Handle(key string, initialMessage string, incomingMessages <-c
 	if err := scanner.Err(); err != nil {
 		// hacky, but can't do a type assertion on the cancellation error, which is the "normal" error received
 		// when the logs are closed properly
-		if !strings.Contains(err.Error(), "request canceled") {
+		if !strings.Contains(err.Error(), "canceled") {
 			log.WithFields(log.Fields{"error": err}).Error("Error with the container log scanner.")
 		}
 	}


### PR DESCRIPTION
The docker client library changed an error message we were looking from
"request canceled" to "context canceled" and code that was looking for
that message is now incorrectly logging an error.

Fix by broadening the search to just match "canceled"