### PR TITLE
Fix that CI does not package windows binary

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -29,7 +29,7 @@ echo Created ../dist/artifacts/go-agent.tar.gz
 
 popd
 
-if [ "$CROSS" == "true" ]; then
+if [ -n "$CROSS" ]; then
     pushd build
     mkdir -p rancher
     cp ../bin/windows/amd64/agent.exe rancher/


### PR DESCRIPTION
When we building release binaries, 'CROSS=1' will be set to environment variable. 
So fix conditional of $CROSS in package script. Using `-n $CROSS` instead of `$CROSS==true`.