### PR TITLE
Change the label name of skip host healthcheck.

### DIFF
--- a/core/hostInfo/os_c.go
+++ b/core/hostInfo/os_c.go
@@ -2,6 +2,7 @@ package hostInfo
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/rancher/agent/model"
 	"github.com/rancher/agent/utilities/constants"
@@ -54,7 +55,7 @@ func (o OSCollector) GetLabels(prefix string) (map[string]string, error) {
 		fmt.Sprintf("%s.%s", prefix, "os"):                             getOSName(),
 	}
 	if getOSName() == "windows" {
-		labels["io.rancher.infra_service.healthcheck.deploy"] = "never"
+		labels["io.rancher.host.healthcheck.deploy_strategy"] = "skip"
 	}
 	return labels, nil
 }


### PR DESCRIPTION
issue refer to https://github.com/rancher/rancher/issues/10442

refer to comments from https://github.com/rancher/cattle/pull/3117

Use `io.rancher.host.healthcheck.deploy_strategy` instead of
    `io.rancher.infra_service.healthcheck.deploy` for consistency.
More extensiablity as using strategy subfix.