### PR TITLE
WIP: Multi-Arch Support, Starting with AMD64 and AArch64 (aka ARM64v8) 

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -20,6 +20,8 @@ ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 
+RUN apt-get install -y binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu
+
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/agent/
 ENV DAPPER_OUTPUT ./bin ./dist

--- a/package/aarch64/Dockerfile
+++ b/package/aarch64/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04@sha256:4ffec8d4ab8efc7e08199bbcbb4bd403b0a29f84c2d617b4349783afa6551f32
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates jq iproute2 && \
+    curl -sLf https://download.docker.com/linux/static/stable/aarch64/docker-17.09.0-ce.tgz > /tmp/docker.tgz && \
+    cd /tmp && tar -xf docker.tgz && mv docker/docker /usr/bin/docker && rm -rf /tmp/docker /tmp/docker.tgz && \
+    chmod +x /usr/bin/docker
+ARG VERSION=dev
+ENV AGENT_IMAGE rancher/agent:${VERSION}
+COPY agent run.sh /usr/bin/
+ENTRYPOINT ["run.sh"]

--- a/package/amd64/Dockerfile
+++ b/package/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04@sha256:6b9eb699512656fc6ef936ddeb45ab25edcd17ab94901790989f89dbf782344a
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates jq iproute2 && \
     curl -sLf https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 > /usr/bin/docker && \

--- a/scripts/build
+++ b/scripts/build
@@ -1,10 +1,17 @@
 #!/bin/bash
 set -e
-
+set -x 
 source $(dirname $0)/version
 
 cd $(dirname $0)/..
 
+# GoLang uses arm64, instead of aarch64 :(
+if [ "${GOARCH}" == "aarch64" ]; then
+  GOARCH=arm64
+  export CGO_ENABLED=1
+  export CC=aarch64-linux-gnu-gcc
+fi
+
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
-CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/agent
+go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/agent-${ARCH}

--- a/scripts/ci
+++ b/scripts/ci
@@ -6,4 +6,5 @@ cd $(dirname $0)
 ./build
 ./test
 ./validate
-./package
+ARCH=aarch64 ./package
+ARCH=amd64 ./package

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,7 +3,8 @@ set -e
 
 cd $(dirname $0)
 
-./build
+GOOS=linux GOARCH=aarch64 ARCH=aarch64 ./build
+GOOS=linux GOARCH=amd64 ARCH=amd64 ./build
 ./test
 ./validate
 ARCH=aarch64 ./package

--- a/scripts/package
+++ b/scripts/package
@@ -4,8 +4,7 @@ set -e
 source $(dirname $0)/version
 
 ARCH=${ARCH:-"amd64"}
-SUFFIX=""
-[ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
+SUFFIX="-${ARCH}"
 
 cd $(dirname $0)/../package
 
@@ -13,12 +12,12 @@ TAG=${TAG:-${VERSION}${SUFFIX}}
 REPO=${REPO:-rancher}
 
 if echo $TAG | grep -q dirty; then
-    TAG=dev
+    TAG=dev${SUFFIX}
 fi
 
 cp ../bin/agent .
 
 IMAGE=${REPO}/agent:${TAG}
-docker build --build-arg VERSION=${TAG} -t ${IMAGE} .
-echo ${IMAGE} > ../dist/images
+docker build --build-arg VERSION=${TAG} -t ${IMAGE} -f ${ARCH}/Dockerfile .
+echo ${IMAGE} >> ../dist/images
 echo Built ${IMAGE}

--- a/scripts/package
+++ b/scripts/package
@@ -15,7 +15,7 @@ if echo $TAG | grep -q dirty; then
     TAG=dev${SUFFIX}
 fi
 
-cp ../bin/agent .
+cp ../bin/agent-${ARCH} ./agent
 
 IMAGE=${REPO}/agent:${TAG}
 docker build --build-arg VERSION=${TAG} -t ${IMAGE} -f ${ARCH}/Dockerfile .


### PR DESCRIPTION
**WIP**

### Known Problems

It seems that the agent on aarch64 boards is unwilling to connect to the Rancher Server. Getting the following error.

* Possibly a problem in the cross compile? The agent binary is in the right exec format as it runs, but unable to get past the WSS handshake.

```
time="2018-11-07T23:08:28Z" level=info msg="Connecting to proxy" url="wss://malcolm.nws-ops-west.nowsecure.io/v3/connect"
time="2018-11-07T23:08:29Z" level=error msg="Failed to connect to proxy" error="websocket: bad handshake"
time="2018-11-07T23:08:29Z" level=error msg="Failed to connect to proxy" error="websocket: bad handshake"
```

### Changes

This will result in one tagged image per architecture, suffixed by the architecture. Changed the suffix to be hyphen not underscore, as that's more the standard.

### Included

* Adds support for building image for multiple architectures
  * Initial support for amd64 and aarch64 (see below for aarch64)
* Each architecture gets it's own ...
  * tag (format: tag-${ARCH})
  * Dockerfile (format: package/${ARCH}/Dockerfile)

### Not Included

* Manifest creation / pushing

### Manifest Creation / Pushing

Manifests can be created by using a tool like https://github.com/estesp/manifest-tool and example spec file that could be generated and used by `./manifest-tool push from-spec spec.yml`

```yaml
image: rancher/agent:dev
manifests:
  - image: rancher/agent:dev-amd64
    platform:
      architecture: amd64
      os: linux
  - image: rancher/agent:dev-aarch64
    platform:
      architecture: arm64
      os: linux
      variant: v8
```

## Why is it called AArch64?

It is arm64, but the more technically correct term. See https://static.docs.arm.com/100878/0100/fundamentals_of_armv8_a_100878_0100_en.pdf