### PR TITLE
Change RBD storage driver to flexvolumes

### DIFF
--- a/core/storage/volume.go
+++ b/core/storage/volume.go
@@ -59,6 +59,7 @@ var rancherDrivers = map[string]bool{
 	"rancher-efs":       true,
 	"rancher-secrets":   true,
 	"secrets-bridge-v2": true,
+	"rancher-rbd":       true,
 }
 
 func VolumeActivateDocker(volume model.Volume, storagePool model.StoragePool, progress *progress.Progress, client *engineCli.Client) error {


### PR DESCRIPTION
Because the Rancher NFS/EBS/Secrets volume drivers have been re-implemented in [Rancher 1.6.15](https://github.com/rancher/rancher/releases/tag/v1.6.15#Enhancements) and the ceph RBD storage driver has the same issue. So change RBD storage driver to use flexvolumes.